### PR TITLE
Open links in new tab & corrected 'Time Remaining' for the event

### DIFF
--- a/index.html
+++ b/index.html
@@ -1828,7 +1828,7 @@
                             "answer": "You can <a href = \"https://cfp.pydelhi.org/pydelhi-conference-2016/proposals/\"> propose </a> a talk for the event."
                         }, {
                             "question": "WHAT FORMS OF PAYMENT AVAILABLE?",
-                            "answer": "You can book your tickets using <a href = \"https://in.explara.com/e/pydelhi-conference\"> Explara </a>. "
+                            "answer": "You can book your tickets using <a href = \"https://in.explara.com/e/pydelhi-conference\" target=\"_blank\" > Explara </a>. "
                         }, {
                             "question": "I WOULD LIKE A SPECIAL PACKAGE TO BRING THE EMPLOYEES OF MY COMPANY, WHAT SHOULD I DO?",
                             "answer": "There are no bulk discouts and special packages. Please book the tickets as individuals."
@@ -2056,11 +2056,11 @@
             <div class="col-sm-12 col-md-6">
                 <!-- Social Icons -->
                 <div class="footer-social-icons">
-                    <a href="http://github.com/pydelhi"><i class="fa fa-github"></i></a>
-                    <a href="http://bit.ly/pydelhi-fb"><i class="fa fa-facebook"></i></a>
-                    <a href="http://bit.ly/pydelhi-twitter"><i class="fa fa-twitter"></i></a>
-                    <a href="http://bit.ly/pydelhi-google"><i class="fa fa-google-plus"></i></a>
-                    <a href="http://bit.ly/pydelhi-youtube"><i class="fa fa-youtube"></i></a>
+                    <a href="http://github.com/pydelhi" target="_blank"><i class="fa fa-github"></i></a>
+                    <a href="http://bit.ly/pydelhi-fb" target="_blank"><i class="fa fa-facebook"></i></a>
+                    <a href="http://bit.ly/pydelhi-twitter" target="_blank"><i class="fa fa-twitter"></i></a>
+                    <a href="http://bit.ly/pydelhi-google" target="_blank"><i class="fa fa-google-plus"></i></a>
+                    <a href="http://bit.ly/pydelhi-youtube" target="_blank"><i class="fa fa-youtube"></i></a>
                 </div>
                 <!-- /Social Icons -->
             </div>
@@ -2068,7 +2068,7 @@
             <!-- col -->
             <div class="col-sm-12 col-md-6">
                 <div class="e2e-networks pull-right">
-                    Hosted by: <a href="https://www.e2enetworks.com">E2E Networks</a>
+                    Hosted by: <a href="https://www.e2enetworks.com" target="_blank">E2E Networks</a>
                 </div>
             </div>
             <!-- /col -->

--- a/js/main.js
+++ b/js/main.js
@@ -4990,7 +4990,7 @@ $(document).ready(function(){
     });
 
   //=====>  Countdown (Edit this with your own date)  <====
-  $("#countdown").countdown("2016/3/5", function(event) {
+  $("#countdown").countdown("2016/3/5 08:30:00", function(event) {
     var $this = $(this).html(event.strftime(''
        + '<div class="countdown-col-wrapper col-xs-6 col-sm-3"><div class="countdown-col"><span class="countdown-time"> %-D </span> <span class="countdown-type"> Days </span></div></div> '
        + '<div class="countdown-col-wrapper col-xs-6 col-sm-3"><div class="countdown-col"><span class="countdown-time"> %H </span> <span class="countdown-type">Hours </span></div></div>'


### PR DESCRIPTION
The social media links and the Explara link in the FAQs was opening on the same page. Corrected the same.

Also corrected the 'Time Remaining' for the event by including  the exact time along with the date.
