### PR TITLE
Add spacing between carousel buttons

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1289,6 +1289,9 @@ body:after {
   font-weight: bold;
   margin-top: 20px;
 }
+.countdown-title2 > a + a {
+  margin-left: 10px;
+}
 @media (min-width: 768px) {
   .countdown-title2 {
     margin-top: 40px;


### PR DESCRIPTION
Currently, the buttons on the carousel have no spacing between them.

![before](https://cloud.githubusercontent.com/assets/7725225/13201349/5ac7c786-d893-11e5-9383-991381c5d022.png)

Added some space between them:

![after](https://cloud.githubusercontent.com/assets/7725225/13201351/7ab8c540-d893-11e5-8372-a2383a34fadc.png)
